### PR TITLE
update for Elixir 0.14.3

### DIFF
--- a/otp/src/tweet_aggregator/lib/tweet_aggregator.ex
+++ b/otp/src/tweet_aggregator/lib/tweet_aggregator.ex
@@ -1,5 +1,5 @@
 defmodule TweetAggregator do
-  use Application.Behaviour
+  use Application
 
   # See http://elixir-lang.org/docs/stable/Application.Behaviour.html
   # for more information on OTP Applications

--- a/otp/src/tweet_aggregator/lib/tweet_aggregator/aggregator.ex
+++ b/otp/src/tweet_aggregator/lib/tweet_aggregator/aggregator.ex
@@ -1,5 +1,5 @@
 defmodule TweetAggregator.Aggregator do
-  use GenServer.Behaviour
+  use GenServer
   alias TweetAggregator.Search.Client.Status
 
   def become_leader do
@@ -29,7 +29,7 @@ defmodule TweetAggregator.Aggregator do
     :gen_server.cast {:global, :aggregator}, {:push, server_name, status}
   end
 
-  defp log(server_name, Status[text: text, username: username]) do
+  defp log(server_name, %Status{text: text, username: username}) do
     IO.puts """
     >> #{server_name}
     @#{username}: #{text}

--- a/otp/src/tweet_aggregator/lib/tweet_aggregator/search/client.ex
+++ b/otp/src/tweet_aggregator/lib/tweet_aggregator/search/client.ex
@@ -1,4 +1,13 @@
+defmodule TweetAggregator.Search.Client.Status do
+  defstruct id: nil, text: "", username: nil, hash_tags: [], mentions: []
+
+end
+defmodule TweetAggregator.Search.Client.Query do
+  defstruct subscriber: nil, keywords: [], options: [], seen_ids: []
+end
 defmodule TweetAggregator.Search.Client do
+  alias TweetAggregator.Search.Client.Status
+  alias TweetAggregator.Search.Client.Query
   alias TweetAggregator.GateKeeper
   alias TweetAggregator.Aggregator
   alias TweetAggregator.Search.Supervisor
@@ -6,18 +15,15 @@ defmodule TweetAggregator.Search.Client do
   @base_url "https://api.twitter.com/1.1/"
   @limit 1
 
-  defrecord Status, id: nil, text: "", username: nil, hash_tags: [], mentions: []
-  defrecord Query, subscriber: nil, keywords: [], options: [], seen_ids: []
-
   def server_name, do: :"#{node}_search_server"
   def server_pid, do: Process.whereis(server_name)
 
   def poll(keywords, options \\ []) do
-    Supervisor.start_link(server_name, Query.new(
+    Supervisor.start_link(server_name, %Query{
       subscriber: spawn(fn -> do_poll end),
       keywords: keywords,
       options: options,
-    ))
+    })
     send server_pid, :poll
   end
   defp do_poll do
@@ -42,11 +48,11 @@ defmodule TweetAggregator.Search.Client do
   end
 
   def get(path, params) do
-    url             = String.to_char_list! process_url("search/tweets.json")
-    access_token    = String.to_char_list! GateKeeper.access_token
-    access_secret   = String.to_char_list! GateKeeper.access_token_secret
-    consumer_key    = String.to_char_list! GateKeeper.consumer_key
-    consumer_secret = String.to_char_list! GateKeeper.consumer_secret
+    url             = String.to_char_list process_url("search/tweets.json")
+    access_token    = String.to_char_list GateKeeper.access_token
+    access_secret   = String.to_char_list GateKeeper.access_token_secret
+    consumer_key    = String.to_char_list GateKeeper.consumer_key
+    consumer_secret = String.to_char_list GateKeeper.consumer_secret
     consumer = {consumer_key, consumer_secret, :hmac_sha1}
 
     case :oauth.get(url, params, consumer, access_token, access_secret) do
@@ -57,9 +63,11 @@ defmodule TweetAggregator.Search.Client do
 
   def parse_response(response) do
     Enum.map to_json(response)["statuses"], fn status ->
-      Status.new id: status["id"],
+      status = status |> Enum.into HashDict.new
+      user = status["user"] |> Enum.into HashDict.new
+      %Status{id: status["id"],
                  text: status["text"],
-                 username: status["user"]["screen_name"]
+                 username: user["screen_name"]}
     end
   end
 
@@ -68,10 +76,11 @@ defmodule TweetAggregator.Search.Client do
     |> elem(2)
     |> to_string
     |> :jsx.decode
+    |> Enum.into HashDict.new
   end
 
   defp keywords_to_query_param(keywords) do
-    keywords |> Enum.join(" OR ") |> String.to_char_list!
+    keywords |> Enum.join(" OR ") |> String.to_char_list
   end
 
   defp process_url(url), do: @base_url <> url

--- a/otp/src/tweet_aggregator/lib/tweet_aggregator/search/server.ex
+++ b/otp/src/tweet_aggregator/lib/tweet_aggregator/search/server.ex
@@ -1,5 +1,5 @@
 defmodule TweetAggregator.Search.Server do
-  use GenServer.Behaviour
+  use GenServer
   alias TweetAggregator.Search.Client
   alias TweetAggregator.Search.Client.Query
 
@@ -27,7 +27,7 @@ defmodule TweetAggregator.Search.Server do
   end
 
   def record_seen_ids(statuses, query) do
-    query.seen_ids(query.seen_ids ++ seen_ids(statuses))
+    %{query | seen_ids: (query.seen_ids ++ seen_ids(statuses))}
   end
 
   def new_results?(statuses, query) do

--- a/otp/src/tweet_aggregator/lib/tweet_aggregator/search/supervisor.ex
+++ b/otp/src/tweet_aggregator/lib/tweet_aggregator/search/supervisor.ex
@@ -1,5 +1,5 @@
 defmodule TweetAggregator.Search.Supervisor do
-  use Supervisor.Behaviour
+  use Supervisor
 
   def stop(server_name) do
     Process.exit Process.whereis(name(server_name)), :shutdown

--- a/otp/src/tweet_aggregator/lib/tweet_aggregator/supervisor.ex
+++ b/otp/src/tweet_aggregator/lib/tweet_aggregator/supervisor.ex
@@ -1,5 +1,5 @@
 defmodule TweetAggregator.Supervisor do
-  use Supervisor.Behaviour
+  use Supervisor
 
   def start_link do
     :supervisor.start_link(__MODULE__, [])

--- a/otp/src/tweet_aggregator/mix.lock
+++ b/otp/src/tweet_aggregator/mix.lock
@@ -1,5 +1,5 @@
-[ "erlang-oauth": {:git, "git://github.com/tim/erlang-oauth.git", "3ad509d487a72f9437fef31a379bf3cfeeb166a2", []},
+%{"erlang-oauth": {:git, "git://github.com/tim/erlang-oauth.git", "3ad509d487a72f9437fef31a379bf3cfeeb166a2", []},
   "httpotion": {:git, "git://github.com/myfreeweb/httpotion.git", "f41ad7b86cf0de5ce2830323290b30f55df17f17", []},
   "ibrowse": {:git, "git://github.com/cmullaparthi/ibrowse.git", "d824491d37449763ac44398f8494731e0c1418c1", []},
   "jsx": {:git, "git://github.com/talentdeficit/jsx.git", "d011411c23e9f8c29d98aa1b7a50ddf9709b6a60", []},
-  "oauth": {:git, "git://github.com/tim/erlang-oauth.git", "3ad509d487a72f9437fef31a379bf3cfeeb166a2", []} ]
+  "oauth": {:git, "git://github.com/tim/erlang-oauth.git", "3ad509d487a72f9437fef31a379bf3cfeeb166a2", []}}


### PR DESCRIPTION
Prior to this commit, the distributed programming exercise had relics
from Elixir 0.13.0, which @chrismccord used to create the exercise:
- `defrecord`
- `String.to_char_list!`

This commit replaces the records with structs, and as a result makes
some hacky compromises with the json decoded from `:jsx`; however,
potentially converting to `:jsex` seemed too large an undertaking. This
commit also updates `String.to_char_list!` to `String.to_char_list`
because `String.to_char_list!` was deprecated and removed.
